### PR TITLE
a guess at adding the host midi port to the UI

### DIFF
--- a/mod/host.py
+++ b/mod/host.py
@@ -849,6 +849,7 @@ class Host(object):
         if self.hasSerialMidiIn:
             websocket.write_message("add_hw_port /graph/serial_midi_in midi 0 Serial_MIDI_In 0")
 
+
         ports = get_jack_hardware_ports(False, False)
         for i in range(len(ports)):
             name = ports[i]
@@ -860,6 +861,9 @@ class Host(object):
             else:
                 title = name.split(":",1)[-1].title().replace(" ","_")
             websocket.write_message("add_hw_port /graph/%s midi 0 %s %i" % (name.split(":",1)[-1], title, i+1))
+
+        #add modulation port so plugins can manipulate or generate midi learn
+        websocket.write_message("add_hw_port /graph/mod-host midi 0 midi_in %i",i+1)
 
         # MIDI Out
         if self.hasSerialMidiOut:


### PR DESCRIPTION
Hi falktx:

I tried to implement the mod-host:midi_in port in the UI, but I can't figure out how to test since the files install to a read-only part of the mod's file system. So I'll just do this PR and you can either tell me how to test or just check it yourself. :)

This adds some cool possibilities like manipulating midi learn to have 1 knob on your midi controller change several parameters on the pedalboard, or having a pedal generate automation (like a midi lfo). Hopefully this can be a useful contribution.