### PR TITLE
Prototype Atom Output Ports, UI notifications

### DIFF
--- a/html/js/host.js
+++ b/html/js/host.js
@@ -92,6 +92,15 @@ $('document').ready(function() {
             return
         }
 
+        if (cmd == "output_atom") {
+            data         = data.substr(cmd.length+1).split(" ",3)
+            var instance = data[0]
+            var symbol   = data[1]
+            var atom     = data[2]
+            desktop.pedalboard.pedalboard("setOutputPortValue", instance, symbol, JSON.parse(atom));
+            return
+        }
+
         if (cmd == "output_set") {
             data         = data.substr(cmd.length+1).split(" ",3)
             var instance = data[0]

--- a/mod/host.py
+++ b/mod/host.py
@@ -1152,7 +1152,10 @@ class Host(object):
             for symbol, value in pluginData['outputs'].items():
                 if value is None:
                     continue
-                websocket.write_message("output_set %s %s %f" % (pluginData['instance'], symbol, value))
+                if isinstance (value, float):
+                    websocket.write_message("output_set %s %s %f" % (pluginData['instance'], symbol, value))
+                if isinstance (value, str):
+                    websocket.write_message("output_atom %s %s %s" % (pluginData['instance'], symbol, value))
 
                 if crashed:
                     self.send_notmodified("monitor_output %d %s" % (instance_id, symbol))


### PR DESCRIPTION
Updated PR #48 

Rebased on master (was temposync2), tested with https://github.com/x42/modspectre.lv2
with most-host/atom-send (d4e51e29d4) rebased onto current mod-host/master (2f1b067)