### PR TITLE
Fix for get_jack_port_alias to return correct MIDI port names.

### DIFF
--- a/utils/utils_jack.cpp
+++ b/utils/utils_jack.cpp
@@ -387,7 +387,7 @@ float get_jack_sample_rate(void)
 
 const char* get_jack_port_alias(const char* portname)
 {
-    static char  aliases[0xff][2];
+    static char  aliases[2][0xff];
     static char* aliasesptr[2] = {
         aliases[0],
         aliases[1]


### PR DESCRIPTION
Without this fix, the names are overwritten on top of each other with an offset of 2, resulting in corrupted string.