### PR TITLE
Indexes

### DIFF
--- a/html/include/bank_pedalboard.html
+++ b/html/include/bank_pedalboard.html
@@ -1,6 +1,7 @@
 <div class="clearfix">
     <div class="pedalboard clearfix">
         <div class="info clearfix">
+            <span class="title alignleft">{{index}}</span>
             <span class="title js-title alignleft">{{title}}</span>
             <span class="js-remove remove" title="remove pedalboard"></span>
         </div>

--- a/html/include/bank_pedalboard.html
+++ b/html/include/bank_pedalboard.html
@@ -1,7 +1,7 @@
 <div class="clearfix">
     <div class="pedalboard clearfix">
         <div class="info clearfix">
-            <span class="title alignleft">{{index}}</span>
+            <span class="title js-index alignleft">{{index}}</span>
             <span class="title js-title alignleft">{{title}}</span>
             <span class="js-remove remove" title="remove pedalboard"></span>
         </div>

--- a/html/js/banks.js
+++ b/html/js/banks.js
@@ -196,7 +196,7 @@ JqueryClass('bankBox', {
         self.data('pedalboardCanvas').children().each(function (i) {
           var pedalboard = $(this)
           var index = pedalboard.find(".js-index")
-          index.html(i + 1 + ".")
+          index.html(i + ".")
         })
     },
 
@@ -227,10 +227,9 @@ JqueryClass('bankBox', {
         bank.data('pedalboards', $('<div>'))
         bank.data('title', bankData.title)
 
-        var i, pedalboardData, rendered, index
+        var i, pedalboardData, rendered
         for (i = 0; i < bankData.pedalboards.length; i++) {
-            index = i + 1
-            rendered = self.bankBox('renderPedalboard', bankData.pedalboards[i], index.toString())
+            rendered = self.bankBox('renderPedalboard', bankData.pedalboards[i], i.toString())
             rendered.find('.js-remove').show()
             rendered.appendTo(bank.data('pedalboards'))
         }

--- a/html/js/banks.js
+++ b/html/js/banks.js
@@ -178,6 +178,7 @@ JqueryClass('bankBox', {
         self.data('save')(serialized, function (ok) {
             if (ok)
                 self.data('saving').html('Auto saving banks... Done!').show()
+              
             else {
                 self.data('saving').html('Auto saving banks... Error!').show()
                 new Notification('error', 'Error saving banks!')
@@ -349,7 +350,8 @@ JqueryClass('bankBox', {
         var self = $(this)
 
         var metadata = {
-            title: index ? index + ". " + pedalboard.title : pedalboard.title,
+            index: index ? index + ". " : index,
+            title: pedalboard.title,
             image: "/img/loading-pedalboard.gif",
         }
 

--- a/html/js/banks.js
+++ b/html/js/banks.js
@@ -74,6 +74,13 @@ JqueryClass('bankBox', {
             cursor: "webkit-grabbing !important",
             revert: true,
             update: function (e, ui) {
+                // Update displayed indexes
+                // self.data('pedalboardCanvas').children().each(function (i) {
+                //   var pedalboard = $(this)
+                //   var index = pedalboard.find(".js-index")
+                //   index.html(i + 1 + ".")
+                // })
+
                 if (self.droppedBundle && !ui.item.data('pedalboardBundle')) {
                     ui.item.data('pedalboardBundle', self.droppedBundle)
                 }
@@ -178,7 +185,7 @@ JqueryClass('bankBox', {
         self.data('save')(serialized, function (ok) {
             if (ok)
                 self.data('saving').html('Auto saving banks... Done!').show()
-              
+
             else {
                 self.data('saving').html('Auto saving banks... Error!').show()
                 new Notification('error', 'Error saving banks!')
@@ -191,6 +198,12 @@ JqueryClass('bankBox', {
                 self.data('saving').hide()
             }, 500)
             self.data('savingTimeout', timeout)
+        })
+        // Update displayed indexes
+        self.data('pedalboardCanvas').children().each(function (i) {
+          var pedalboard = $(this)
+          var index = pedalboard.find(".js-index")
+          index.html(i + 1 + ".")
         })
     },
 

--- a/html/js/banks.js
+++ b/html/js/banks.js
@@ -220,9 +220,10 @@ JqueryClass('bankBox', {
         bank.data('pedalboards', $('<div>'))
         bank.data('title', bankData.title)
 
-        var i, pedalboardData, rendered
+        var i, pedalboardData, rendered, index
         for (i = 0; i < bankData.pedalboards.length; i++) {
-            rendered = self.bankBox('renderPedalboard', bankData.pedalboards[i])
+            index = i + 1
+            rendered = self.bankBox('renderPedalboard', bankData.pedalboards[i], index.toString())
             rendered.find('.js-remove').show()
             rendered.appendTo(bank.data('pedalboards'))
         }
@@ -344,11 +345,11 @@ JqueryClass('bankBox', {
         })
     },
 
-    renderPedalboard: function (pedalboard) {
+    renderPedalboard: function (pedalboard, index = "") {
         var self = $(this)
 
         var metadata = {
-            title: pedalboard.title,
+            title: index ? index + ". " + pedalboard.title : pedalboard.title,
             image: "/img/loading-pedalboard.gif",
         }
 

--- a/html/js/banks.js
+++ b/html/js/banks.js
@@ -74,13 +74,6 @@ JqueryClass('bankBox', {
             cursor: "webkit-grabbing !important",
             revert: true,
             update: function (e, ui) {
-                // Update displayed indexes
-                // self.data('pedalboardCanvas').children().each(function (i) {
-                //   var pedalboard = $(this)
-                //   var index = pedalboard.find(".js-index")
-                //   index.html(i + 1 + ".")
-                // })
-
                 if (self.droppedBundle && !ui.item.data('pedalboardBundle')) {
                     ui.item.data('pedalboardBundle', self.droppedBundle)
                 }

--- a/html/js/snapshot.js
+++ b/html/js/snapshot.js
@@ -65,6 +65,8 @@ function SnapshotsManager(options) {
         }
 
         var selected = options.editingElem = options.pedalPresetsList.find('option:selected')
+        var selectedHtml = selected.html()
+        var name = selectedHtml.substring(selectedHtml.indexOf(".") + 1);
 
         options.pedalPresetsOverlay.css({
             position: "absolute",
@@ -72,7 +74,7 @@ function SnapshotsManager(options) {
             height: selected.height()+2,
             top: selected.position().top,
             left: selected.position().left
-        }).prop("value", selected.html()).show().focus()
+        }).prop("value", name).show().focus()
 
         return false
     })
@@ -104,6 +106,11 @@ function SnapshotsManager(options) {
                     options.pedalPresetsWindow.find('.js-assign-all').addClass('disabled')
                     options.pedalPresetsWindow.find('.js-delete').addClass('disabled')
                 }
+
+                options.pedalPresetsList.children().each(function(i) {
+                  console.log(i)
+                  console.log($(this).html())
+                })
             },
             error: function () {},
             cache: false,
@@ -181,7 +188,8 @@ function SnapshotsManager(options) {
 
             // add new ones
             for (var i in presets) {
-                var elem = $('<option value="'+i+'">'+presets[i]+'</option>')
+                var index = parseInt(i) + 1
+                var elem = $('<option value="'+i+'">'+index + "."+ presets[i]+'</option>')
 
                 if (currentId == i && ! options.currentlyAddressed) {
                     elem.prop('selected', 'selected')
@@ -253,7 +261,6 @@ function SnapshotsManager(options) {
         var text = options.pedalPresetsOverlay.hide().val()
         var elem = options.editingElem
         var prId = elem.val()
-
         options.editingElem = null
 
         if (text == "") {
@@ -268,7 +275,8 @@ function SnapshotsManager(options) {
                 title: text,
             },
             success: function () {
-                elem.html(text)
+                var index = parseInt(prId) + 1
+                elem.html(index + "." + text)
                 options.renamedCallback(text)
             },
             error: function () {},

--- a/html/js/snapshot.js
+++ b/html/js/snapshot.js
@@ -188,7 +188,7 @@ function SnapshotsManager(options) {
 
             // add new ones
             for (var i in presets) {
-                var index = parseInt(i) + 1
+                var index = parseInt(i)
                 var elem = $('<option value="'+i+'">'+index + "."+ presets[i]+'</option>')
 
                 if (currentId == i && ! options.currentlyAddressed) {
@@ -226,7 +226,9 @@ function SnapshotsManager(options) {
         self.hideRenameOverlay()
 
         var selectId = $(this).val()
-        var prtitle  = $(this).html()
+
+        var selectedHtml = $(this).html()
+        var prtitle = selectedHtml.substring(selectedHtml.indexOf(".") + 1)
 
         if (options.currentlyAddressed) {
             options.pedalPresetsList.find('option:selected').removeProp('selected')
@@ -275,7 +277,7 @@ function SnapshotsManager(options) {
                 title: text,
             },
             success: function () {
-                var index = parseInt(prId) + 1
+                var index = parseInt(prId)
                 elem.html(index + "." + text)
                 options.renamedCallback(text)
             },

--- a/html/js/snapshot.js
+++ b/html/js/snapshot.js
@@ -107,9 +107,14 @@ function SnapshotsManager(options) {
                     options.pedalPresetsWindow.find('.js-delete').addClass('disabled')
                 }
 
-                options.pedalPresetsList.children().each(function(i) {
-                  console.log(i)
-                  console.log($(this).html())
+                // Replace options value and text so we can a sequential list 0, 1, 2, etc.
+                var i = 0
+                options.pedalPresetsList.children().each(function(option) {
+                  var optionHtml = $(this).html()
+                  var prtitle = optionHtml.substring(optionHtml.indexOf(".") + 1)
+                  $(this).html(i + "." + prtitle)
+                  $(this).val(i)
+                  i++
                 })
             },
             error: function () {},
@@ -188,8 +193,7 @@ function SnapshotsManager(options) {
 
             // add new ones
             for (var i in presets) {
-                var index = parseInt(i)
-                var elem = $('<option value="'+i+'">'+index + "."+ presets[i]+'</option>')
+                var elem = $('<option value="'+i+'">'+i + "."+ presets[i]+'</option>')
 
                 if (currentId == i && ! options.currentlyAddressed) {
                     elem.prop('selected', 'selected')
@@ -277,8 +281,7 @@ function SnapshotsManager(options) {
                 title: text,
             },
             success: function () {
-                var index = parseInt(prId)
-                elem.html(index + "." + text)
+                elem.html(prId + "." + text)
                 options.renamedCallback(text)
             },
             error: function () {},

--- a/mod/host.py
+++ b/mod/host.py
@@ -153,7 +153,7 @@ class Host(object):
         self.banks = list_banks()
 
         self.profile = Profile()
-        
+
         self.allpedalboards = None
         self.bank_id = 0
         self.connections = []
@@ -163,7 +163,7 @@ class Host(object):
         self.hasSerialMidiIn = False
         self.hasSerialMidiOut = False
         self.hasMidiMergerOut = False
-        self.hasMidiBroadcasterIn = False        
+        self.hasMidiBroadcasterIn = False
         self.pedalboard_empty    = True
         self.pedalboard_modified = False
         self.pedalboard_name     = ""
@@ -309,12 +309,12 @@ class Host(object):
 
         Protocol.register_cmd_callback("get_master_volume_channel", self.hmi_get_master_volume_channel)
         Protocol.register_cmd_callback("set_master_volume_channel", self.hmi_set_master_volume_channel)
-        
+
         Protocol.register_cmd_callback("get_tuner_mute", self.hmi_get_tuner_mute)
         Protocol.register_cmd_callback("set_tuner_mute", self.hmi_set_tuner_mute)
-        
+
         Protocol.register_cmd_callback("get_pb_name", self.hmi_get_pb_name)
-        
+
         ioloop.IOLoop.instance().add_callback(self.init_host)
 
     def __del__(self):
@@ -337,7 +337,7 @@ class Host(object):
                     ptype = "cv"
                 else:
                     ptype = "audio"
-            
+
             index = 100 + int(name.rsplit("_",1)[-1])
             title = name.title().replace(" ","_")
             self.msg_callback("add_hw_port /graph/%s %s %i %s %i" % (name, ptype, int(isOutput), title, index))
@@ -632,7 +632,7 @@ class Host(object):
         # Setup MIDI program navigation
         self.send_notmodified("set_midi_program_change_pedalboard_bank_channel %d %d" % (1, self.profile.midi_prgch_bank_channel))
         self.send_notmodified("set_midi_program_change_pedalboard_snapshot_channel %d %d" % (1, self.profile.midi_prgch_snapshot_channel))
-        
+
         # Wait for all mod-host messages to be processed
         yield gen.Task(self.send_notmodified, "feature_enable processing 2", datatype='boolean')
 
@@ -750,7 +750,7 @@ class Host(object):
         if bank_id > 0 and pedalboard and bank_id <= len(self.banks):
             bank = self.banks[bank_id-1]
             pedalboards = bank['pedalboards']
-            
+
             # navigateFootswitches = bank['navigateFootswitches']
             # if "navigateChannel" in bank.keys() and not navigateFootswitches:
             #     bankNavigateChannel = int(bank['navigateChannel'])-1
@@ -763,7 +763,7 @@ class Host(object):
             bank_id = 0
             pedalboard = DEFAULT_PEDALBOARD
             pedalboards = self.allpedalboards
-            
+
             # navigateFootswitches = False
             # bankNavigateChannel = 15
 
@@ -954,11 +954,11 @@ class Host(object):
                     pedalboards = self.banks[self.bank_id-1]['pedalboards']
                 else:
                     pedalboards = self.allpedalboards
-                
+
                 if program >= 0 and program < len(pedalboards):
                     bundlepath = pedalboards[program]['bundle']
                     self.send_notmodified("feature_enable processing 0")
-                    
+
                     def load_callback(ok):
                         self.bank_id = bank_id
                         self.load(bundlepath)
@@ -971,7 +971,7 @@ class Host(object):
             elif channel == self.profile.midi_prgch_snapshot_channel:
                 yield gen.Task(self.snapshot_load, program)
                 pass
-                    
+
         elif cmd == "transport":
             msg_data = msg[len(cmd)+1:].split(" ",3)
             rolling  = bool(int(msg_data[0]))
@@ -1028,7 +1028,7 @@ class Host(object):
                 self.profile.set_midi_prgch_snapshot_channel(channel)
             else:
                 self.profile.midi_prgch_snapshot_channel = -1 # off
-        
+
         else:
             logging.error("[host] unrecognized command: %s" % cmd)
 
@@ -1113,7 +1113,7 @@ class Host(object):
             self.process_write_queue()
 
     # send data to host, don't change modified flag
-    def send_notmodified(self, msg, callback=None, datatype='int'):        
+    def send_notmodified(self, msg, callback=None, datatype='int'):
         self._queue.append((msg, callback, datatype))
         logging.info("[host] idle? -> %s" % self._idle)
         if self._idle:
@@ -1205,16 +1205,16 @@ class Host(object):
                 websocket.write_message("add_hw_port /graph/midi_merger_out midi 0 All_MIDI_In 1")
                 # TODO: Is that instance name special or random?
                 #   2018-10-31, Jakob thinks: random but has to match
-                #   in function _fix_host_connection_port()                
+                #   in function _fix_host_connection_port()
                 # TODO: Is that name special or used at all?
                 #   2018-10-31, Jakob thinks: used in <div/>.
 
             # NOTE: The midi-merger automatically connects to available hardware ports.
-            
+
         else: # 'legacy' mode until version 1.6
             if self.hasSerialMidiIn:
                 websocket.write_message("add_hw_port /graph/serial_midi_in midi 0 Serial_MIDI_In 0")
-                
+
             ports = get_jack_hardware_ports(False, False)
             for i in range(len(ports)):
                 name = ports[i]
@@ -1238,7 +1238,7 @@ class Host(object):
         else:
             if self.hasSerialMidiOut:
                 websocket.write_message("add_hw_port /graph/serial_midi_out midi 1 Serial_MIDI_Out 0")
-          
+
             ports = get_jack_hardware_ports(False, True)
             for i in range(len(ports)):
                 name = ports[i]
@@ -1800,8 +1800,10 @@ class Host(object):
         if idx < 0 or idx >= len(self.pedalboard_snapshots) or self.pedalboard_snapshots[idx] is None:
             return False
 
+        snapshot_to_remove = self.pedalboard_snapshots[idx]
         self.pedalboard_modified = True
-        self.pedalboard_snapshots[idx] = None
+        self.pedalboard_snapshots.remove(snapshot_to_remove)
+        logging.info(self.pedalboard_snapshots)
         return True
 
     @gen.coroutine
@@ -1924,10 +1926,10 @@ class Host(object):
             if data[2].startswith("cv_playback_"):
                 num = data[2].replace("cv_playback_", "", 1)
                 return "mod-fake-control-voltage:cv_playback_{0}".format(num)
-            
+
             # Default guess
             return "system:%s" % data[2]
-        
+
         instance    = "/graph/%s" % data[2]
         portsymbol  = data[3]
         instance_id = self.mapper.get_id_without_creating(instance)
@@ -2930,7 +2932,7 @@ _:b%i
             self.send_notmodified("set_midi_program_change_pedalboard_snapshot_channel 1 %d" % channel)
 
 
-                    
+
     # -----------------------------------------------------------------------------------------------------------------
     # Host stuff - timers
 
@@ -3431,7 +3433,7 @@ _:b%i
     def hmi_get_truebypass_value(self, right, callback):
         """Query the True Bypass setting of the given channel."""
         logging.info("hmi true bypass get ({0})".format(right))
-        
+
         bypassed = get_truebypass_value(right)
         callback(True, int(bypassed))
 
@@ -3440,7 +3442,7 @@ _:b%i
         logging.info("hmi true bypass set to ({0}, {1})".format(right, bypassed))
 
         set_truebypass_value(right, bypassed)
-        
+
         # TODO should it return some more status?
         callback(True)
 
@@ -3449,7 +3451,7 @@ _:b%i
         bpm = get_jack_data(True)['bpm']
         logging.info("hmi get tempo bpm: {0}".format(bpm))
         callback(True, bpm)
-        
+
     def hmi_set_tempo_bpm(self, bpm, callback):
         """Set the Jack BPM."""
         logging.info("hmi tempo bpm set to {0}".format(bpm))
@@ -3463,7 +3465,7 @@ _:b%i
         logging.info("hmi tempo bpb get")
         bpb = get_jack_data(True)['bpb']
         callback(True, bpb)
-        
+
     def hmi_set_tempo_bpb(self, bpb, callback):
         """Set the Jack Beats Per Bar."""
         logging.info("hmi tempo bpb set to {0}".format(bpb))
@@ -3475,16 +3477,16 @@ _:b%i
     def hmi_get_snapshot_prgch(self, callback):
         """Query the MIDI channel for selecting a snapshot via Program Change."""
         logging.info("hmi get snapshot channel")
-        
+
         channel = self.profile.midi_prgch_snapshot_channel
         # NOTE: Assume this value is always the same as in mod-host.
-        
+
         callback(True, channel)
 
     def hmi_set_snapshot_prgch(self, channel, callback):
         """Set the MIDI channel for selecting a snapshot via Program Change."""
         logging.info("hmi set snapshot channel {0}".format(channel))
-        
+
         if self.profile.set_midi_prgch_snapshot_channel(channel):
             self.send_notmodified("set_midi_program_change_pedalboard_snapshot_channel 1 %d" % channel)
             callback(True)
@@ -3494,7 +3496,7 @@ _:b%i
     def hmi_get_bank_prgch(self, callback):
         """Query the MIDI channel for selecting a pedalboard in a bank via Program Change."""
         logging.info("hmi get bank channel")
-        
+
         channel = self.profile.midi_prgch_bank_channel
         callback(True, channel)
 
@@ -3511,11 +3513,11 @@ _:b%i
     def hmi_get_clk_src(self, callback):
         """Query the tempo and transport sync mode."""
         logging.info("hmi get clock source")
-        
+
         mode = self.profile.sync_mode
         # NOTE: We assume the state in mod-host will only change if
         # `hmi_set_clk_src()` is called!
-        
+
         callback(True, int(mode))
 
     def hmi_set_clk_src(self, mode, callback):
@@ -3534,7 +3536,7 @@ _:b%i
             if mode == 2: # Ableton Link
                 self.send_notmodified("feature_enable midi_clock_slave 0")
                 self.send_notmodified("feature_enable link 1")
-                
+
             self.profile.sync_mode = mode
             callback(True)
         else:
@@ -3544,7 +3546,7 @@ _:b%i
     def hmi_get_send_midi_clk(self, callback):
         """Query the status of sending MIDI Beat Clock."""
         logging.info("hmi get midi beat clock status")
-        
+
         onoff = 1 # TODO: communicate with mod-host
         callback(True, int(onoff))
 
@@ -3563,7 +3565,7 @@ _:b%i
         logging.info("hmi retrieve profile")
         result = self.profile.retrieve(index)
         callback(result)
-        
+
     def hmi_store_profile(self, index, callback):
         """Trigger storing current profile to `index`."""
         logging.info("hmi store profile")
@@ -3575,7 +3577,7 @@ _:b%i
         logging.info("hmi get exp/cv mode")
         mode = self.profile.configurable_input_mode
         callback(True, mode)
-        
+
     def hmi_set_exp_cv(self, mode, callback):
         """Set the mode of the configurable input."""
         logging.info("hmi set exp/cv mode to {0}".format(mode))
@@ -3590,7 +3592,7 @@ _:b%i
         logging.info("hmi get hp/cv mode")
         mode = self.profile.configurable_output_mode
         callback(True, mode)
-        
+
     def hmi_set_hp_cv(self, mode, callback):
         """Set the mode of the configurable output."""
         logging.info("hmi set hp/cv mode to {0}".format(mode))
@@ -3613,7 +3615,7 @@ _:b%i
             callback(True, link)
         else:
             callback(False)
-            
+
     # Given a odd channel number `oddch` the link state with the
     # following even channel is setlinked to `link`. Returns "resp -1"
     # on error, else "resp 0".
@@ -3640,7 +3642,7 @@ _:b%i
             callback(True, link)
         else:
             callback(False)
-            
+
     # Given a odd channel number `oddch` the link state with the
     # following even channel is setlinked to `link`. Returns "resp -1"
     # on error, else "resp 0".
@@ -3658,7 +3660,7 @@ _:b%i
         logging.info("hmi get display brightness")
         value = self.profile.display_brightness
         callback(True, value)
-        
+
     def hmi_set_display_brightness(self, brightness, callback):
         """Set the display_brightness."""
         logging.info("hmi set display brightness to {0}".format(brightness))
@@ -3673,7 +3675,7 @@ _:b%i
         logging.info("hmi get master volume channel mode")
         value = self.profile.master_volume_channel_mode
         callback(True, value)
-        
+
     def hmi_set_master_volume_channel_mode(self, mode, callback):
         """Set the mode how the master volume is linked to the channel output volumes."""
         logging.info("hmi set master volume channel mode to {0}".format(mode))
@@ -3695,7 +3697,7 @@ _:b%i
     def hmi_get_master_volume_channel(self, callback):
         """TODO."""
         callback(True, 0) # integer 0, 1, 2
-        
+
     def hmi_set_master_volume_channel(self, value, callback):
         """TODO."""
         callback(True)
@@ -3707,13 +3709,13 @@ _:b%i
     def hmi_set_tuner_mute(self, value, callback):
         """TODO."""
         callback(True)
-        
+
     def hmi_get_pb_name(self, callback):
         """Return the name of the currently loaded pedalboard."""
         name = str(self.pedalboard_name)
         callback(True, name) # string
 
-        
+
     # -----------------------------------------------------------------------------------------------------------------
     # JACK stuff
 


### PR DESCRIPTION
- Added indexes to Snapshots manager pop-up. Rearrange snapshots indexes after deleting one so we always get a sequential list of indexes: 0, 1, 2, etc. and not for instance 0, 2, etc. after deleting 1, as it was before
- Added indexes to Pedalboards in Banks. Indexes are rearranged after dragging, adding or deleting a pedalboard to/from the bank so it always displays ordered indexes.