### PR TITLE
[DX-124] Use hmi_si descriptor to send 'si' cmd to hmi or not

### DIFF
--- a/mod/hmi.py
+++ b/mod/hmi.py
@@ -347,9 +347,9 @@ class HMI(object):
             self.control_set_index(hw_id, index, n_controllers, callback)
 
         cb = callback
-        platform = get_hardware_descriptor().get('platform', 'Unknown')
+        hmi_si = get_hardware_descriptor().get('hmi_si', 0)
 
-        if not actuator_uri.startswith("/hmi/footswitch") and platform == 'duo':
+        if not actuator_uri.startswith("/hmi/footswitch") and hmi_si:
             cb = control_add_callback
 
         self.send('a %d %s %d %s %f %f %f %d %s' %

--- a/mod/hmi.py
+++ b/mod/hmi.py
@@ -347,9 +347,9 @@ class HMI(object):
             self.control_set_index(hw_id, index, n_controllers, callback)
 
         cb = callback
-        hmi_si = get_hardware_descriptor().get('hmi_si', 0)
+        hmi_set_index = get_hardware_descriptor().get('hmi_set_index', 0)
 
-        if not actuator_uri.startswith("/hmi/footswitch") and hmi_si:
+        if not actuator_uri.startswith("/hmi/footswitch") and hmi_set_index:
             cb = control_add_callback
 
         self.send('a %d %s %d %s %f %f %f %d %s' %


### PR DESCRIPTION
Related to this discussion: https://github.com/moddevices/mod-ui/commit/67db8599032ed98fbeb8602e8dca8e73ff11e9c9#commitcomment-33618435

It now uses `hmi_si` hardware descriptor: 0 (default value if not provided) if command not supported by hmi or 1 if supported.
Therefore `"hmi_si": 1` should be added to `mod-hardware-descriptor.json` on the Duo.