### PR TITLE
FIX #333: MOD-UI Featured plugins do not wrap around correctly

### DIFF
--- a/html/js/cloudplugin.js
+++ b/html/js/cloudplugin.js
@@ -370,7 +370,7 @@ JqueryClass('cloudPluginBox', {
             results.shopify = {}
             renderResults();
         });
-        
+
 
         // cloud search
         var cloudResults
@@ -660,8 +660,13 @@ JqueryClass('cloudPluginBox', {
         var plugin, render
 		var factory = function(img) {
 			return function() {
-				img.css('padding-top', (parseInt((img.parent().height()-img.height())/2))+'px');
-				img.css('opacity', 1)
+			    img.css('opacity', 1)
+                            var top = (parseInt((img.parent().height()-img.height())/2))+'px'
+                            // We need to put a padding in image, but slick creates clones of the
+                            // element to use on carousel, so we need padding in all clones
+                            var uri = img.parent().parent().parent().parent().attr('mod-uri')
+                            var clones = $('div.slick-slide[mod-uri="'+uri+'"][mod-role="cloud-plugin"]')
+                            clones.find('img').css('padding-top', top);
 			};
 		}
 


### PR DESCRIPTION
Vertical align of icon is made by assigning a padding-top to the image after the carousel is rendered. But Slick clones the element and use clones to show peripheral items, so we need to find all clones to apply the padding-top.