### PR TITLE
ENV Variables for mod-host Address and local dev

### DIFF
--- a/host_debug.py
+++ b/host_debug.py
@@ -8,7 +8,7 @@ import sys, tornado, time, socket
 #from tornado import web, options
 
 s = socket.socket()
-s.connect(os.getenv['MOD_HOST_ADDR'], 5555)
+s.connect(os.environ['MOD_HOST_ADDR'], 5555)
 #s.settimeout(0.2)
 
 fh = open(sys.argv[1])

--- a/host_debug.py
+++ b/host_debug.py
@@ -8,7 +8,7 @@ import sys, tornado, time, socket
 #from tornado import web, options
 
 s = socket.socket()
-s.connect(os.environ['MOD_HOST_ADDR'], 5555)
+s.connect(os.getenv['MOD_HOST_ADDR'], 5555)
 #s.settimeout(0.2)
 
 fh = open(sys.argv[1])

--- a/host_debug.py
+++ b/host_debug.py
@@ -8,7 +8,7 @@ import sys, tornado, time, socket
 #from tornado import web, options
 
 s = socket.socket()
-s.connect(('localhost', 5555))
+s.connect(os.environ['MOD_HOST_ADDR'], 5555)
 #s.settimeout(0.2)
 
 fh = open(sys.argv[1])

--- a/mod/host.py
+++ b/mod/host.py
@@ -221,7 +221,7 @@ class Host(object):
         self.prefs = prefs
         self.msg_callback = msg_callback
 
-        self.addr = ("mod-host", 5555)
+        self.addr = (os.environ['MOD_HOST_ADDR'], 5555)
         self.readsock = None
         self.writesock = None
         self.crashed = False

--- a/mod/host.py
+++ b/mod/host.py
@@ -221,7 +221,7 @@ class Host(object):
         self.prefs = prefs
         self.msg_callback = msg_callback
 
-        self.addr = (os.environ['MOD_HOST_ADDR'], 5555)
+        self.addr = (os.getenv['MOD_HOST_ADDR'], 5555)
         self.readsock = None
         self.writesock = None
         self.crashed = False

--- a/mod/host.py
+++ b/mod/host.py
@@ -276,7 +276,11 @@ class Host(object):
         self.processing_pending_flag = False
         self.init_plugins_data()
 
-        if APP and os.getenv("MOD_LIVE_ISO") is not None:
+
+	     if os.getenv("USE_STANDARD_JACK_OUTPUTS") is not None:
+            self.jack_hwin_prefix  = "system:playback_"
+            self.jack_hwout_prefix = "system:capture_"	  
+        else if APP and os.getenv("MOD_LIVE_ISO") is not None:
             self.jack_hwin_prefix  = "system:playback_"
             self.jack_hwout_prefix = "system:capture_"
         else:

--- a/mod/host.py
+++ b/mod/host.py
@@ -277,10 +277,10 @@ class Host(object):
         self.init_plugins_data()
 
 
-	     if os.getenv("USE_STANDARD_JACK_OUTPUTS") is not None:
+        if os.getenv("USE_STANDARD_JACK_OUTPUTS") is not None:
             self.jack_hwin_prefix  = "system:playback_"
-            self.jack_hwout_prefix = "system:capture_"	  
-        else if APP and os.getenv("MOD_LIVE_ISO") is not None:
+            self.jack_hwout_prefix = "system:capture_"
+        elif APP and os.getenv("MOD_LIVE_ISO") is not None:
             self.jack_hwin_prefix  = "system:playback_"
             self.jack_hwout_prefix = "system:capture_"
         else:

--- a/mod/host.py
+++ b/mod/host.py
@@ -221,7 +221,7 @@ class Host(object):
         self.prefs = prefs
         self.msg_callback = msg_callback
 
-        self.addr = (os.getenv['MOD_HOST_ADDR'], 5555)
+        self.addr = ("mod-host", 5555)
         self.readsock = None
         self.writesock = None
         self.crashed = False

--- a/mod/host.py
+++ b/mod/host.py
@@ -221,7 +221,7 @@ class Host(object):
         self.prefs = prefs
         self.msg_callback = msg_callback
 
-        self.addr = ("localhost", 5555)
+        self.addr = (os.environ['MOD_HOST_ADDR'], 5555)
         self.readsock = None
         self.writesock = None
         self.crashed = False

--- a/server.py
+++ b/server.py
@@ -43,6 +43,7 @@ os.environ['MOD_DEVICE_KEY'] = join(DATA_DIR, 'rsa')
 os.environ['MOD_DEVICE_TAG'] = join(DATA_DIR, 'tag')
 os.environ['MOD_DEVICE_UID'] = join(DATA_DIR, 'uid')
 os.environ['MOD_API_KEY'] = join(DATA_DIR, 'mod_api_key.pub')
+os.environ['MOD_HOST_ADDR'] = os.environ.get("MOD_HOST_ADDR", 'localhost')
 
 create_dummy_credentials()
 


### PR DESCRIPTION
Hi, thanks for the amazing work!
I've managed to make mod-ui + mod-host work under docker (connecting to host JACK), but needed to change some variables and needed to use standard JACK outputs. 

This PR adds two ENV Variables:

MOD_HOST_ADDR = to connect to mod-host on other than localhost USE_STANDARD_JACK_OUTPUTS = To use default JACK outputs names without setting MOD_APP

Use case: https://github.com/ajboni/mod-docker/blob/master/mod-ui/Dockerfile#L30 