### PR TITLE
Only call callback if callable

### DIFF
--- a/mod/host.py
+++ b/mod/host.py
@@ -2201,7 +2201,8 @@ class Host(object):
 
         if symbol in pluginData['designations']:
             print("ERROR: Trying to modify a specially designated port '%s', stop!" % symbol)
-            callback(False)
+            if callable(callback):
+                callback(False)
             return
 
         pluginData['ports'][symbol] = value
@@ -2213,7 +2214,8 @@ class Host(object):
 
         if uri in pluginData['designations']:
             print("ERROR: Trying to modify a specially designated parameter '%s', stop!" % uri)
-            callback(False)
+            if callable(callback):
+                callback(False)
             return
 
         # pluginData['parameters'][uri] = value


### PR DESCRIPTION
I stumbled upon an issue where Host.param_set() is called with a None callback, and then callback(False) raises an exception.
I propose checking that callback is callable.