### PR TITLE
Prevent horizontal scrolling on iOS Safari

### DIFF
--- a/html/css/less/main.less
+++ b/html/css/less/main.less
@@ -143,8 +143,12 @@ body {
 
 body {
   background: #111;
+  min-width: 1024px;
 
-  min-width: 980px;
+  // set document body to have 980px min-width on iOS devices to match default virtual viewport width
+  &.ios {
+    min-width: 980px;
+  }
 }
 
 * {

--- a/html/css/less/main.less
+++ b/html/css/less/main.less
@@ -145,8 +145,11 @@ body {
   background: #111;
   min-width: 1024px;
 
-  // set document body to have 980px min-width on iOS devices to match default virtual viewport width
+  // iOS/iPadOS device-specific styles
   &.ios {
+    // prevent vertical inertia scrolling
+    position: fixed;
+    // set 980px min-width to match default virtual viewport width
     min-width: 980px;
   }
 }

--- a/html/css/less/main.less
+++ b/html/css/less/main.less
@@ -144,7 +144,7 @@ body {
 body {
   background: #111;
 
-  min-width: 1024px;
+  min-width: 980px;
 }
 
 * {

--- a/html/index.html
+++ b/html/index.html
@@ -243,9 +243,8 @@ $('document').ready(function() {
             'iPhone',
             'iPod'
         ].includes(navigator.platform);
-        var isiOSUserAgent = navigator.userAgent.includes("iPad") ||
-            navigator.userAgent.includes("iPhone");
         var isiPadOS13SUserAgent = (navigator.userAgent.includes("Mac") && "ontouchend" in document);
+        var isiOSUserAgent = /(iPad|iPhone|iPod)/g.test(navigator.userAgent);
         var isiOS = isiOSPlatform || isiPadOS13SUserAgent || isiOSUserAgent;
 
         if (isiOS) {

--- a/html/index.html
+++ b/html/index.html
@@ -232,6 +232,26 @@ $('document').ready(function() {
         dataType: 'json'
     });
     */
+
+    // add iOS/iPadOS-specific document body class `.ios`
+    (function () {
+        var isiOSPlatform = [
+            'iPad Simulator',
+            'iPhone Simulator',
+            'iPod Simulator',
+            'iPad',
+            'iPhone',
+            'iPod'
+        ].includes(navigator.platform);
+        var isiOSUserAgent = navigator.userAgent.includes("iPad") ||
+            navigator.userAgent.includes("iPhone");
+        var isiPadOS13SUserAgent = (navigator.userAgent.includes("Mac") && "ontouchend" in document);
+        var isiOS = isiOSPlatform || isiPadOS13SUserAgent || isiOSUserAgent;
+
+        if (isiOS) {
+            $('body').addClass('ios');
+        }
+    })();
 })
 </script>
 


### PR DESCRIPTION
**Issue:**

When using mod-ui in Safari on an iPad running iOS 14, I am able to touch-and-drag on either the plugin tab buttons or  main menu area, which results in a horizontal scroll that cuts off the left edge of the Pedalboard UI.

iOS Safari seems to be ignoring the `overflow: hidden` style on the root `<html>` tag, and the `overflow: hidden` on the `<body>` doesn't prevent scrolling since it has `min-width: 1024px`, which appears to conflict with the [iOS Safari default virtual viewport width of 980px](https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariWebContent/UsingtheViewport/UsingtheViewport.html).

**NOTE:** This issue only appears on a physical device -- using mod-ui in the Xcode iOS simulator works normally.