### PR TITLE
Add instructions on loading mod-monitor

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -46,6 +46,10 @@ mod-ui depends on mod-host and the JACK server running in order to make sound. S
 
     $ mod-host -n -p 5555 -f 5556
 
+You should also load the `mod-monitor` module into jack (without it you won't be able to connect to output ports):
+
+    $ jack_load mod-monitor
+
 If you do not have mod-host, you can tell mod-ui to fake the connection to the audio backend.
 You will not get any audio, but you will be able to load plugins, make connections, save pedalboards and all that. For this, run::
 


### PR DESCRIPTION
Add a sentence to the README instructing the user to load mod-monitor prior to
running the server.

Fixes issue #112.