### PR TITLE
Use port aliases for audio hardware port display names

### DIFF
--- a/mod/host.py
+++ b/mod/host.py
@@ -2066,7 +2066,7 @@ class Host(object):
         # Audio In
         for i in range(len(self.audioportsIn)):
             name  = self.audioportsIn[i]
-            title = name.title().replace(" ","_")
+            title = self.get_port_name_alias("system:" + name).replace(" ","_")
             websocket.write_message("add_hw_port /graph/%s audio 0 %s %i" % (name, title, i+1))
 
         # Control Voltage In
@@ -2078,7 +2078,7 @@ class Host(object):
         # Audio Out
         for i in range(len(self.audioportsOut)):
             name  = self.audioportsOut[i]
-            title = name.title().replace(" ","_")
+            title = self.get_port_name_alias("system:" + name).replace(" ","_")
             websocket.write_message("add_hw_port /graph/%s audio 1 %s %i" % (name, title, i+1))
 
         # Control Voltage Out


### PR DESCRIPTION
## Summary

Use `get_port_name_alias()` for audio hardware ports, same as already done for MIDI ports (line 616). This allows custom hardware to set JACK port aliases and have them displayed correctly in the UI.

## Problem

Audio port display names are derived from the raw JACK port name (`capture_1` → `Capture_1`). For custom hardware (non-MOD devices running mod-ui), there's no way to show meaningful names like "IN L" or "Guitar In".

## Solution

Replace `name.title()` with `self.get_port_name_alias("system:" + name)` which:
- Returns the JACK port alias if one is set (e.g. via `jack_alias`)
- Falls back to `portname.split(":",1)[-1].title()` when no alias exists (backward compatible)

This is the same function already used for MIDI port names.

## Testing

Tested on Raspberry Pi CM5 with custom I2S soundcard (PCM1863 + PCM5242). JACK aliases set via systemd service `ExecStartPost`. UI correctly displays custom port names.